### PR TITLE
Kaldi now requires python2 *and* python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y  \
     libtool-bin \
     make \
     python2.7 \
+    python3 \
     python-pip \
     python-yaml \
     python-simplejson \


### PR DESCRIPTION
Add python3 to the list of dependencies, as it is now required by
Kaldi `check_dependencies.sh` script.

This change was introduced in Kaldi at:
https://github.com/kaldi-asr/kaldi/commit/8ad898c2b8a506d10b9c2fb31949a148aed6844d

fixes #23