### PR TITLE
Updated Dockerfile

### DIFF
--- a/examples/practical-example/Dockerfile
+++ b/examples/practical-example/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Eduardo Silva <zedudu@gmail.com>
 # This is the practical example part
 
 RUN mkdir -p /opt/models && cd /opt/models && \
-    wget https://phon.ioc.ee/~tanela/tedlium_nnet_ms_sp_online.tgz && \
+    wget --no-check-certificate https://phon.ioc.ee/~tanela/tedlium_nnet_ms_sp_online.tgz && \
     tar -zxvf tedlium_nnet_ms_sp_online.tgz && \
     wget https://raw.githubusercontent.com/alumae/kaldi-gstreamer-server/master/sample_english_nnet2.yaml -P /opt/models && \
     find /opt/models/ -type f | xargs sed -i 's:test:/opt:g' && \


### PR DESCRIPTION
wget complains about the certificate of the site hosting tedlium models:

> ERROR: cannot verify phon.ioc.ee's certificate, issued by ‘CN=TERENA SSL CA 3,O=TERENA,L=Amsterdam,ST=Noord-Holland,C=NL’:
>   Unable to locally verify the issuer's authority.

added '--no-check-certificate' flag to wget to ignore the cert check