### PR TITLE
Add dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get update && apt-get install -y  \
     python-gi \
     subversion \
     wget \
+    build-essential \
+    python-dev \
+    sox \
     zlib1g-dev && \
     apt-get clean autoclean && \
     apt-get autoremove -y && \


### PR DESCRIPTION
tornado.speedups extension module needs build-essential and python-dev for compilation.  
In extras/check_dependencies.sh (Kaldi project) is recommended to install sox.
Should resolve #40.