### PR TITLE
Add missing unzip dependency, response to issue #51

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y  \
     python-simplejson \
     python-gi \
     subversion \
+    unzip \
     wget \
     build-essential \
     python-dev \


### PR DESCRIPTION
Add this missing unzip dependency needed in the most recent version. This version is build en available for testing on Dockerhub `docker pull bk203/docker-kaldi-gstreamer-server`