### PR TITLE
fix tornado version to 5.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y  \
     apt-get clean autoclean && \
     apt-get autoremove -y && \
     pip install ws4py==0.3.2 && \
-    pip install tornado && \    
+    pip install tornado==5.1.1 && \    
     ln -s /usr/bin/python2.7 /usr/bin/python ; ln -s -f bash /bin/sh
 
 WORKDIR /opt


### PR DESCRIPTION
Fixes the following exception when building docker image from git and running /opt/start.sh

> Traceback (most recent call last):
>   File "/opt/kaldi-gstreamer-server/kaldigstserver/worker.py", line 21, in <module>
>        import tornado.gen 
>   File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 126
>         def _value_from_stopiteration(e: Union[StopIteration, "Return"]) -> Any: