### PR TITLE
Fix #65: Explicitly configure with Atlas math lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN git clone https://github.com/kaldi-asr/kaldi && \
     cd /opt/kaldi/tools && \
     make && \
     ./install_portaudio.sh && \
-    cd /opt/kaldi/src && ./configure --shared && \
+    cd /opt/kaldi/src && ./configure --mathlib=ATLAS --shared && \
     sed -i '/-g # -O0 -DKALDI_PARANOID/c\-O3 -DNDEBUG' kaldi.mk && \
     make depend && make && \
     cd /opt/kaldi/src/online && make depend && make && \


### PR DESCRIPTION
Fix the build on latest version of Kaldi