### PR TITLE
Add missing dependencies & improve container lifecycle

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,11 @@
+kind: pipeline
+name: default
+
+steps:
+- name: build  
+  image: plugins/docker
+  settings:
+    username: stargate01
+    password:
+      from_secret: docker_password
+    repo: stargate01/docker-kaldi-gstreamer-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,3 +76,5 @@ COPY start.sh stop.sh /opt/
 
 RUN chmod +x /opt/start.sh && \
     chmod +x /opt/stop.sh 
+
+ENTRYPOINT ["/opt/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN git clone https://github.com/kaldi-asr/kaldi && \
     find /opt/kaldi/src/ -type f -not -name '*.so' -delete && \
     find /opt/kaldi/tools/ -type f \( -not -name '*.so' -and -not -name '*.so*' \) -delete && \
     cd /opt && git clone https://github.com/alumae/kaldi-gstreamer-server.git && \
+    cd /opt/kaldi-gstreamer-server && git checkout 25274489f2f04f5d144a592fbf661db46f12a463 && \
     rm -rf /opt/kaldi-gstreamer-server/.git/ && \
     rm -rf /opt/kaldi-gstreamer-server/test/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN git clone https://github.com/kaldi-asr/kaldi && \
     make -j $(nproc) && \
     ./install_portaudio.sh && \
     /opt/kaldi/tools/extras/install_mkl.sh && \
-    cd /opt/kaldi/src && ./configure --shared && \
+    cd /opt/kaldi/src && ./configure --mathlib=ATLAS --shared && \
     sed -i '/-g # -O0 -DKALDI_PARANOID/c\-O3 -DNDEBUG' kaldi.mk && \
     make clean -j $(nproc) && make -j $(nproc) depend && make -j $(nproc) && \
     cd /opt/kaldi/src/online && make depend -j $(nproc) && make -j $(nproc) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:9
-MAINTAINER Eduardo Silva <zedudu@gmail.com>
 
 RUN apt-get update && apt-get install -y  \
     procps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y  \
     automake \
     bzip2 \
     g++ \
+    gfortran \
     git \
     gstreamer1.0-plugins-good \
     gstreamer1.0-tools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y  \
     apt-get clean autoclean && \
     apt-get autoremove -y && \
     pip install ws4py==0.3.2 && \
-    pip install tornado && \    
+    pip install tornado==4.5.3 && \    
     ln -s /usr/bin/python2.7 /usr/bin/python ; ln -s -f bash /bin/sh
 
 WORKDIR /opt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+[![Build Status](https://drone-github.chrz.de/api/badges/StarGate01/docker-kaldi-gstreamer-server/status.svg)](https://drone-github.chrz.de/StarGate01/docker-kaldi-gstreamer-server)
+[![Docker Pulls](https://img.shields.io/docker/pulls/stargate01/docker-kaldi-gstreamer-server)](https://hub.docker.com/r/stargate01/docker-kaldi-gstreamer-server)
+
 # docker-kaldi-gstreamer-server
+
 Dockerfile for [kaldi-gstreamer-server](https://github.com/alumae/kaldi-gstreamer-server).
 
 Synopsis

--- a/start.sh
+++ b/start.sh
@@ -30,13 +30,14 @@ if [ -z "$YAML" ] || [ ! -f "$YAML" ] ; then
   exit 1;
 fi;
 
+trap /opt/stop.sh SIGINT SIGTERM SIGHUP
 
 if [ "$MASTER" == "localhost" ] ; then
   # start a local master
-  python /opt/kaldi-gstreamer-server/kaldigstserver/master_server.py --port=$PORT 2>> /opt/master.log &
+  (python /opt/kaldi-gstreamer-server/kaldigstserver/master_server.py --port=$PORT | while read line; do echo "[master] $line"; done) &
 fi
 
 #start worker and connect it to the master
 export GST_PLUGIN_PATH=/opt/gst-kaldi-nnet2-online/src/:/opt/kaldi/src/gst-plugin/
 
-python /opt/kaldi-gstreamer-server/kaldigstserver/worker.py -c $YAML -u ws://$MASTER:$PORT/worker/ws/speech 2>> /opt/worker.log &
+python /opt/kaldi-gstreamer-server/kaldigstserver/worker.py -c $YAML -u ws://$MASTER:$PORT/worker/ws/speech | while read line; do echo "[worker] $line"; done

--- a/stop.sh
+++ b/stop.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Shutting down ..."
+
 #kill worker
 ps axf | grep worker.py | grep -v grep | awk '{print "kill -15 " $1}' | sh
 


### PR DESCRIPTION
I added the missing `gfortran` dependency, which is required to build recent versions of kaldi.

Also, I added an entrypoint to the Dockerfile, and redirected the output to stdout in order for it to go to the docker logs.